### PR TITLE
Fix spellcheck false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ,
+ignore-words-list = als
 skip = ./.licenses,.git,__pycache__,node_modules,go.mod,go.sum,package-lock.json,poetry.lock,yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =


### PR DESCRIPTION
The codespell spellchecker tool is used to detect occurrences of commonly misspelled words in the project files.

The project readme references the acronym "ALS" (ambient light sensor). This happens to be in the codespell misspelled
word dictionary as a misspelling of "also", and so causes a failure of the spellcheck.

The false positive is resolved by adding the word to the ignore list in the codespell configuration.