### PR TITLE
Fix parentheses compiler warning in getALS

### DIFF
--- a/src/LTR381RGB.cpp
+++ b/src/LTR381RGB.cpp
@@ -387,8 +387,8 @@ void LTR381RGBClass::getALS(uint8_t * buf, int& ir, int& rawlux, int& lux) {
   int gain = getLuxGain(_gain);
   float intTime = getLuxIntTime(_adcResolution);
 
-  ir = resolution &  buf[2] << 16 | buf[1] << 8 | buf[0];
-  rawlux = resolution & buf[5] << 16 | buf[4] << 8 | buf[3];
+  ir = resolution & ((buf[2] << 16) | (buf[1] << 8) | buf[0]);
+  rawlux = resolution & ((buf[5] << 16) | (buf[4] << 8) | buf[3]);
   lux = ((0.8f*rawlux)/(gain*intTime))*(1 - (0.033f*(ir/rawlux)));
 }
 


### PR DESCRIPTION
`getALS` produced the following compiler warning:
```
/Users/tajozsi/Documents/Arduino/libraries/Arduino_LTR381RGB/src/LTR381RGB.cpp:390:19: warning:
suggest parentheses around arithmetic in operand of '|' [-Wparentheses] 
390 | ir = resolution & (buf[2] << 16) | (buf[1] << 8) | buf[0];
        | ~~~~~~~~~~~^~~~~~~~~~~~~~~~
```
Eliminated the warning by adding parentheses. Note, that the parentheses now change the order of evaluation - but I think this new order was the original intention. Light_Basic.ino produces the same output as before.

Tested and working on a Nano Matter.
